### PR TITLE
Update to Python 3

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,6 @@ Main authors:
 
     British Broadcasting Corporation
         Yves Raimond <yves.raimond at bbc.co.uk>
+        Stephen jolly <stephen.jolly at rd.bbc.co.uk>
+
+Contributions are also gratefully acknowledged from Abram Hindle.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ supported by ffmpeg.
 Installation
 ------------
 
-To install from this source directory:
+To install from this source directory once downloaded:
 
     $ pip install .
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple tool for finding the offset of an audio file within another
 file. 
 
 Uses cross-correlation of standardised Mel-Frequency Cepstral Coefficients,
-so should be relatively robust to noise (encoding, compression, etc).
+so should be relatively robust to noise (encoding, compression, etc).  The accuracy is typically to within about 0.01s.
 
 It uses ffmpeg for transcoding, so should work on all file formats
 supported by ffmpeg.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ supported by ffmpeg.
 Installation
 ------------
 
+To install from this source directory:
+
+    $ pip install .
+
+Or, to install the latest package from PyPi.org:
+
     $ pip install audio-offset-finder
 
 Usage

--- a/audio_offset_finder/audio_offset_finder.py
+++ b/audio_offset_finder/audio_offset_finder.py
@@ -1,6 +1,6 @@
 # audio-offset-finder
 #
-# Copyright (c) 2014 British Broadcasting Corporation
+# Copyright (c) 2014-22 British Broadcasting Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,11 +16,14 @@
 
 from subprocess import Popen, PIPE
 from scipy.io import wavfile
-from scikits.talkbox.features.mfcc import mfcc
+import librosa
 import os, tempfile, warnings
 import numpy as np
 
-def find_offset(file1, file2, fs=8000, trim=60*15, correl_nframes=1000):
+def mfcc(audio, win_length=256, nfft=512, fs=16000, hop_length=128, numcep=13):
+    return [np.transpose(librosa.feature.mfcc(y=audio, sr=fs, n_fft=nfft, win_length=win_length, hop_length=hop_length, n_mfcc=numcep))]
+
+def find_offset(file1, file2, fs=8000, trim=60*15, hop_length=128, win_length=256, correl_nframes=1000):
     tmp1 = convert_and_trim(file1, fs, trim)
     tmp2 = convert_and_trim(file2, fs, trim)
     # Removing warnings because of 18 bits block size
@@ -33,14 +36,14 @@ def find_offset(file1, file2, fs=8000, trim=60*15, correl_nframes=1000):
     # (only seems to happen in ffmpeg, not in sox)
     a1 = ensure_non_zero(a1)
     a2 = ensure_non_zero(a2)
-    mfcc1 = mfcc(a1, nwin=256, nfft=512, fs=fs, nceps=13)[0]
-    mfcc2 = mfcc(a2, nwin=256, nfft=512, fs=fs, nceps=13)[0]
+    mfcc1 = mfcc(a1, win_length=win_length, nfft=512, fs=fs, hop_length=hop_length, numcep=26)[0]
+    mfcc2 = mfcc(a2, win_length=win_length, nfft=512, fs=fs, hop_length=hop_length, numcep=26)[0]
     mfcc1 = std_mfcc(mfcc1)
     mfcc2 = std_mfcc(mfcc2)
     c = cross_correlation(mfcc1, mfcc2, nframes=correl_nframes)
     max_k_index = np.argmax(c)
-    # The MFCC window overlap is hardcoded in scikits.talkbox
-    offset = max_k_index * 160.0 / float(fs) # * over / sample rate
+    offset = (max_k_index) * hop_length / fs
+    
     score = (c[max_k_index] - np.mean(c)) / np.std(c) # standard score of peak
     os.remove(tmp1)
     os.remove(tmp2)

--- a/bin/audio-offset-finder
+++ b/bin/audio-offset-finder
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # audio-offset-finder
 #
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from audio_offset_finder import find_offset
+from audio_offset_finder.audio_offset_finder import find_offset
 import argparse, sys
 
 def main():
@@ -31,9 +31,9 @@ def main():
     args = parser.parse_args()
     if not (args.find_offset_of or args.within):
         parser.error("Please input audio files")
-    offset, score = find_offset(args.within, args.find_offset_of, args.sr, args.trim)
-    print "Offset: %s (seconds)" % str(offset)
-    print "Standard score: %s" % str(score)
+    offset, score = find_offset(args.within, args.find_offset_of, fs=int(args.sr), trim=int(args.trim))
+    print("Offset: %s (seconds)" % str(offset))
+    print("Standard score: %s" % str(score))
 
 if __name__ == '__main__':
     main()

--- a/bin/audio-offset-finder
+++ b/bin/audio-offset-finder
@@ -2,7 +2,7 @@
 
 # audio-offset-finder
 #
-# Copyright (c) 2014 British Broadcasting Corporation
+# Copyright (c) 2014-22 British Broadcasting Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import setup
 
 setup(
     name='audio-offset-finder',
-    version='0.3.0',
+    version='0.4.0',
     description='Find the offset of an audio file within another audio file',
     author='Yves Raimond',
     author_email='yves.raimond@bbc.co.uk',
@@ -30,7 +30,7 @@ setup(
     install_requires=[
         'scipy>=0.12.0',
         'numpy',
-        'scikits.talkbox', 
+        'librosa', 
     ],
     scripts=['bin/audio-offset-finder'],
 )

--- a/tests/offset_finder_tests.py
+++ b/tests/offset_finder_tests.py
@@ -41,6 +41,10 @@ def test_find_offset():
     assert(score > 10)
     offset, score = find_offset(path('timbl_2.mp3'), path('timbl_1.mp3'), hop_length=160, trim=35) 
     assert(score < 10) # No good offset found
+    offset, score = find_offset(path('timbl_1.mp3'), path('timbl_2.mp3'), hop_length=160, trim=1) 
+    assert(score < 10) # No good offset found
+    with assert_raises(InsufficientAudioException):
+        offset, score = find_offset(path('timbl_1.mp3'), path('timbl_2.mp3'), hop_length=160, trim=0.1)
 
 def test_ensure_non_zero():
     signal = np.zeros(100)

--- a/tests/offset_finder_tests.py
+++ b/tests/offset_finder_tests.py
@@ -26,7 +26,7 @@ def path(test_file):
 def test_find_offset():
     # timbl_1.mp3: Full file
     # timbl_2.mp3: File truncated at 12.265 seconds
-    # timbl_3.mp3: File truncated at 12.265 seconds with white noise added to it
+    # timbl_3.mp3: File truncated at 12.242 seconds with white noise added to it
     offset, score = find_offset(path('timbl_1.mp3'), path('timbl_2.mp3'), hop_length=160, trim=35) 
     assert_almost_equal(offset, 12.26)
     assert(score > 10)

--- a/tests/offset_finder_tests.py
+++ b/tests/offset_finder_tests.py
@@ -1,6 +1,6 @@
 # audio-offset-finder
 #
-# Copyright (c) 2014 British Broadcasting Corporation
+# Copyright (c) 2014-22 British Broadcasting Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from nose.tools import *
-from audio_offset_finder import *
+from audio_offset_finder.audio_offset_finder import *
 from numpy.testing import *
 import numpy as np
 import os
@@ -25,21 +25,21 @@ def path(test_file):
 
 def test_find_offset():
     # timbl_1.mp3: Full file
-    # timbl_2.mp3: File truncated at 12.28 seconds
-    # timbl_3.mp3: File truncated at 12.28 seconds with white noise added to it
-    offset, score = find_offset(path('timbl_1.mp3'), path('timbl_2.mp3'), trim=35) 
-    assert_almost_equal(offset, 12.28)
-    assert(score > 10)
-    offset, score = find_offset(path('timbl_1.mp3'), path('timbl_3.mp3'), trim=35)
+    # timbl_2.mp3: File truncated at 12.265 seconds
+    # timbl_3.mp3: File truncated at 12.265 seconds with white noise added to it
+    offset, score = find_offset(path('timbl_1.mp3'), path('timbl_2.mp3'), hop_length=160, trim=35) 
     assert_almost_equal(offset, 12.26)
     assert(score > 10)
-    offset, score = find_offset(path('timbl_1.mp3'), path('timbl_1.mp3'), trim=35) 
+    offset, score = find_offset(path('timbl_1.mp3'), path('timbl_3.mp3'), hop_length=160, trim=35)
+    assert_almost_equal(offset, 12.24)
+    assert(score > 10)
+    offset, score = find_offset(path('timbl_1.mp3'), path('timbl_1.mp3'), hop_length=160, trim=35) 
     assert_almost_equal(offset, 0.0)
     assert(score > 10)
-    offset, score = find_offset(path('timbl_2.mp3'), path('timbl_2.mp3'), trim=35) 
+    offset, score = find_offset(path('timbl_2.mp3'), path('timbl_2.mp3'), hop_length=160, trim=35) 
     assert_almost_equal(offset, 0.0)
     assert(score > 10)
-    offset, score = find_offset(path('timbl_2.mp3'), path('timbl_1.mp3'), trim=35) 
+    offset, score = find_offset(path('timbl_2.mp3'), path('timbl_1.mp3'), hop_length=160, trim=35) 
     assert(score < 10) # No good offset found
 
 def test_ensure_non_zero():


### PR DESCRIPTION
This pull request comprises a fairly minimal set of changes to get the tool working with Python 3.  Some minor documentation tweaks have been included too.

Unfortunately the scitalk.talkbox library used in the original version of this tool has not been updated with Python 3 support, so the code has been altered to use librosa for this task instead.

As a consequence, the offsets calculated by the tool have changed slightly - generally by less than 0.01s, which is the typical accuracy of the tool anyway.  The tests have been updated to reflect these changes.