### PR TITLE
Set numpy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,8 @@ setup(
     packages=['audio_offset_finder'],
     install_requires=[
         'scipy>=0.12.0',
-        'numpy',
-        'librosa', 
+        'numpy>=1.18.0,<1.22.0',
+        'librosa',
     ],
     scripts=['bin/audio-offset-finder'],
 )
-


### PR DESCRIPTION
See #15. This PR fixes an installation issue with Python 3.9, by ensuring a numpy version that's compatible with [numba](https://pypi.org/project/numba/) is used.

