### PR TITLE
Add basic testing of command-line tool to unit tests

### DIFF
--- a/bin/audio-offset-finder
+++ b/bin/audio-offset-finder
@@ -19,7 +19,7 @@
 from audio_offset_finder.audio_offset_finder import find_offset
 import argparse, sys
 
-def main(args):
+def main(argv):
     parser = argparse.ArgumentParser(
         description="Find the offset of an audio file within another one", 
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
@@ -31,7 +31,7 @@ def main(args):
     parser.add_argument('--resolution', metavar='samples', type=int, default=128, help='Resolution (maximum accuracy) of search in samples')
     parser.add_argument('--show-plot', action='store_true', dest='show_plot', help='Display plot of cross-correlation results')
     parser.add_argument('--save-plot', metavar='plot file', dest='plot_file', type=str, help='Save a plot of cross-correlation results to a file (format chosen from extension - png, ps, pdf, svg)')    
-    args = parser.parse_args(args)
+    args = parser.parse_args(argv)
     if not (args.find_offset_of or args.within):
         parser.error("Please provide input audio files")
     results = find_offset(args.within, args.find_offset_of, fs=int(args.sr), trim=int(args.trim), hop_length=int(args.resolution))

--- a/bin/audio-offset-finder
+++ b/bin/audio-offset-finder
@@ -19,7 +19,7 @@
 from audio_offset_finder.audio_offset_finder import find_offset
 import argparse, sys
 
-def main():
+def main(args):
     parser = argparse.ArgumentParser(
         description="Find the offset of an audio file within another one", 
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
@@ -31,9 +31,9 @@ def main():
     parser.add_argument('--resolution', metavar='samples', type=int, default=128, help='Resolution (maximum accuracy) of search in samples')
     parser.add_argument('--show-plot', action='store_true', dest='show_plot', help='Display plot of cross-correlation results')
     parser.add_argument('--save-plot', metavar='plot file', dest='plot_file', type=str, help='Save a plot of cross-correlation results to a file (format chosen from extension - png, ps, pdf, svg)')    
-    args = parser.parse_args()
+    args = parser.parse_args(args)
     if not (args.find_offset_of or args.within):
-        parser.error("Please input audio files")
+        parser.error("Please provide input audio files")
     results = find_offset(args.within, args.find_offset_of, fs=int(args.sr), trim=int(args.trim), hop_length=int(args.resolution))
     print("Offset: %s (seconds)" % str(results["offset"]))
     print("Standard score: %s" % str(results["score"]))
@@ -48,4 +48,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Extends test coverage to the tool, by importing it from its file and then calling it with simulated command-line arguments.

Not every option is covered, but the code in question is not complicated, so I'm hoping a representative selection will do for now.  The focus is on testing the functionality specific to the tool; the library is covered by other tests.