### PR TITLE
Suppress divide by zero when correlation peak has zero width

### DIFF
--- a/audio_offset_finder/audio_offset_finder.py
+++ b/audio_offset_finder/audio_offset_finder.py
@@ -146,7 +146,10 @@ def find_offset_between_buffers(buffer1, buffer2, fs, hop_length=128, win_length
     time_scale = hop_length / fs
     time_offset = (max_k_frame_offset) * time_scale
 
-    score = (c[max_k_index] - np.mean(c)) / np.std(c)  # standard score of peak
+    if np.std(c) < 1e-10:
+        score = inf
+    else:
+        score = (c[max_k_index] - np.mean(c)) / np.std(c)  # standard score of peak
     return {
         "time_offset": time_offset,
         "frame_offset": int(max_k_index),


### PR DESCRIPTION
This change suppresses an unhelpfully phrased warning when a divide by zero occurs.  Asserting that the divide by zero results in the standard score being infinity will probably annoy mathematicians, but it's probably more helpful than any other arbitrarily large number.

Other options exist, but start down a path of adding functionality to the tool to analyse input files and explain why they might not be producing an expected correlation result.