### PR TITLE
Add stderr text to exception thrown when ffmpeg invocation fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 bin/
 lib/
 pyvenv.cfg
+.python-version

--- a/audio_offset_finder/audio_offset_finder.py
+++ b/audio_offset_finder/audio_offset_finder.py
@@ -227,7 +227,7 @@ def convert_and_trim(afile, fs, trim):
         [
             "ffmpeg",
             "-loglevel",
-            "panic",
+            "error",
             "-i",
             afile,
             "-ac",
@@ -246,6 +246,6 @@ def convert_and_trim(afile, fs, trim):
         text=True,
     )
     stdout, stderr = psox.communicate()
-    if not psox.returncode == 0:
-        raise Exception("FFMpeg failed:\n" + stderr)
+    if psox.returncode != 0:
+        raise Exception("FFMpeg failed:\n" + stderr.strip())
     return tmp_name

--- a/audio_offset_finder/audio_offset_finder.py
+++ b/audio_offset_finder/audio_offset_finder.py
@@ -243,8 +243,9 @@ def convert_and_trim(afile, fs, trim):
             tmp_name,
         ],
         stderr=PIPE,
+        text=True,
     )
-    psox.communicate()
+    stdout, stderr = psox.communicate()
     if not psox.returncode == 0:
-        raise Exception("FFMpeg failed")
+        raise Exception("FFMpeg failed:\n" + stderr)
     return tmp_name

--- a/tests/audio_offset_finder_test.py
+++ b/tests/audio_offset_finder_test.py
@@ -63,6 +63,7 @@ def test_find_offset_between_files():
     assert exception.value.args[0].startswith("FFMpeg failed:\n")
     assert exception.value.args[0].endswith("No such file or directory")
 
+
 def test_std_mfcc():
     m = np.array([[2, 3, 4], [4, 5, 5]])
     s1 = np.std([2, 4])

--- a/tests/audio_offset_finder_test.py
+++ b/tests/audio_offset_finder_test.py
@@ -58,6 +58,10 @@ def test_find_offset_between_files():
     results = find_offset_between_files(path("timbl_1.mp3"), path("timbl_2.mp3"), hop_length=160, max_frames=100)
     print((results["time_offset"], results["standard_score"]))
 
+    with pytest.raises(Exception) as exception:
+        find_offset_between_files(path("dummy.mp3"), path("timbl_2.mp3"), hop_length=160, trim=0.1)
+    assert exception.value.args[0].startswith("FFMpeg failed:\n")
+    assert exception.value.args[0].endswith("No such file or directory")
 
 def test_std_mfcc():
     m = np.array([[2, 3, 4], [4, 5, 5]])


### PR DESCRIPTION
Local testing on a machine with a faulty ffmpeg installation resulted in an ffmpeg invocation failure, which revealed that the current code suppresses ffmpeg output, preventing debugging.  This PR captures stderr when invoking ffmpeg and adds it to the exception thrown when ffmpeg invocation fails.