### PR TITLE
Add automated testing on Python 3.11

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Dependency support is now available for Python 3.11, so let's add build/test against that Python version to our automation.

Python 3.12 support is still pending for Numba, so we can't build for that yet.