### PR TITLE
Add exception handler

### DIFF
--- a/audio_offset_finder/cli.py
+++ b/audio_offset_finder/cli.py
@@ -51,9 +51,14 @@ def main(argv):
     args = parser.parse_args(argv)
     if not (args.find_offset_of and args.within):
         parser.error("Please provide input audio files")
-    results = find_offset_between_files(
-        args.within, args.find_offset_of, fs=int(args.sr), trim=int(args.trim), hop_length=int(args.resolution)
-    )
+
+    try:
+        results = find_offset_between_files(
+            args.within, args.find_offset_of, fs=int(args.sr), trim=int(args.trim), hop_length=int(args.resolution)
+        )
+    except Exception as e:
+        print(e, file=sys.stderr)
+        return 1
 
     if args.output_json:
         import json


### PR DESCRIPTION
Currently, if you pass an incorrect filename to the `audio-offset-finder` CLI it prints a Python stack trace. This PR adds an exception handler to just print the actual error:

Before:

```
$ audio-offset-finder --find-offset-of timbl_1.mp3 --within timbl_2.mp3 --show-plot --save-plot example.png
Traceback (most recent call last):
  File "/home/chrisn/.local/bin/audio-offset-finder", line 8, in <module>
    sys.exit(run())
  File "/home/chrisn/.local/lib/python3.8/site-packages/audio_offset_finder/cli.py", line 119, in run
    sys.exit(main(sys.argv[1:]))
  File "/home/chrisn/.local/lib/python3.8/site-packages/audio_offset_finder/cli.py", line 54, in main
    results = find_offset_between_files(
  File "/home/chrisn/.local/lib/python3.8/site-packages/audio_offset_finder/audio_offset_finder.py", line 81, in find_offset_between_files
    tmp1 = convert_and_trim(file1, fs, trim)
  File "/home/chrisn/.local/lib/python3.8/site-packages/audio_offset_finder/audio_offset_finder.py", line 250, in convert_and_trim
    raise Exception("FFMpeg failed:\n" + stderr.strip())
Exception: FFMpeg failed:
timbl_2.mp3: No such file or directory
```

After:

```
$ audio-offset-finder --find-offset-of timbl_1.mp3 --within timbl_2.mp3 --show-plot --save-plot example.png
Exception: FFMpeg failed:
timbl_2.mp3: No such file or directory
```