### PR TITLE
Update codeql version and authors list

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -69,4 +69,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/AUTHORS
+++ b/AUTHORS
@@ -3,5 +3,6 @@ Main authors:
     British Broadcasting Corporation
         Yves Raimond <yves.raimond at bbc.co.uk>
         Stephen jolly <stephen.jolly at rd.bbc.co.uk>
+        Chris Needham <chris.needham at bbc.co.uk>
 
 Contributions are also gratefully acknowledged from Abram Hindle.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = audio-offset-finder
-version = 0.5.4
+version = 0.5.5
 author = Yves Raimond, Stephen Jolly, Chris Needham
 author_email = stephen.jolly@rd.bbc.co.uk
 url = https://github.com/bbcrd/audio-offset-finder

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = audio-offset-finder
 version = 0.5.4
-author = Yves Raimond, Stephen Jolly
+author = Yves Raimond, Stephen Jolly, Chris Needham
 author_email = stephen.jolly@rd.bbc.co.uk
 url = https://github.com/bbcrd/audio-offset-finder
 license = Apache License 2.0


### PR DESCRIPTION
CodeQL v2 has been deprecated; updating to v3
Also updating the authors list to reflect recent contributions.